### PR TITLE
update trivial for lgtm

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -18,3 +18,5 @@ extraction:
         - "cd ${LGTM_SRC}/build"
         - "cmake .."
         - "cmake --build . -j2"
+        - "cd .."
+        - "rm -r 3Party/*"

--- a/src/rasterizer.hpp
+++ b/src/rasterizer.hpp
@@ -64,10 +64,10 @@ public:
     Rasterizer(): Rasterizer(0,0) {};
 
     //getters
-    const int width() const {return width_;}
-    const int height() const {return height_;}
+    int width() const {return width_;}
+    int height() const {return height_;}
     const auto & framebuffer() {return frame_buffer_;}
-    const float getZBuffer(int x,int y) {return z_buffer_(y,x);}
+    float getZBuffer(int x,int y) {return z_buffer_(y,x);}
     std::tuple<int, int> get_framebuffer_shape() {
         return {frame_buffer_.dimension(0),frame_buffer_.dimension(1)};
     }


### PR DESCRIPTION
使lgtm不检查opencv库，减少分析时间